### PR TITLE
[BUGFIX] request.getPageArguments().get('L') returns error

### DIFF
--- a/Configuration/TypoScript/setup.txt
+++ b/Configuration/TypoScript/setup.txt
@@ -57,7 +57,7 @@ page.jsFooterInline.957.wrap (
 	|
 	});
 )
-[request.getPageArguments().get('L') < 1]
+[request.getPageArguments()] && [request.getPageArguments().get('L') < 1]
 page.jsFooterInline.957.10 = TEXT
 page.jsFooterInline.957.10.value = {$plugin.jn_lighterbox.albumLabel}
 page.jsFooterInline.957.10.required = 1


### PR DESCRIPTION
...when object does not exist.

The error log is filled with error messages because request.getPageArguments() not always returns an object depending on the context.