### PR TITLE
[TASK] Add version number to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,8 @@
 	},
     "extra": {
 		"typo3/cms": {
-			"extension-key": "jn_lighterbox"
+			"extension-key": "jn_lighterbox",
+			"version": "1.3.8"
 		}
 	}
 }


### PR DESCRIPTION
In preparation for dropping `ext_emconf.php` in the future, the extension version number should be set in `composer.json`. See [feature 108345](https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/14.2/Feature-108345-No-ext-em-conf-in-classic-mode.html) in the TYPO3 v14x change log.
